### PR TITLE
edits to enable python 2 and 3 simultaneous compatibility

### DIFF
--- a/blackbody.py
+++ b/blackbody.py
@@ -67,11 +67,11 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import division, absolute_import, print_function
+
 import math, numpy, pylab
 
-import colormodels
-import ciexyz
-import plots
+from . import colormodels, ciexyz, plots
 
 # Physical constants in mks units
 PLANCK_CONSTANT   = 6.6237e-34      # J-sec
@@ -104,7 +104,7 @@ def blackbody_spectrum (T_K):
     '''Get the spectrum of a blackbody, as a numpy array.'''
     spectrum = ciexyz.empty_spectrum()
     (num_rows, num_cols) = spectrum.shape
-    for i in xrange (0, num_rows):
+    for i in range (0, num_rows):
         specific_intensity = blackbody_specific_intensity (spectrum [i][0], T_K)
         # scale by size of wavelength interval
         spectrum [i][1] = specific_intensity * ciexyz.delta_wl_nm * 1.0e-9
@@ -135,7 +135,7 @@ def blackbody_color_vs_temperature_plot (T_list, title, filename):
     '''Draw a color vs temperature plot for the given temperature range.'''
     num_T = len (T_list)
     rgb_list = numpy.empty ((num_T, 3))
-    for i in xrange (0, num_T):
+    for i in range (0, num_T):
         T_i = T_list [i]
         xyz = blackbody_color (T_i)
         rgb_list [i] = colormodels.rgb_from_xyz (xyz)

--- a/ciexyz.py
+++ b/ciexyz.py
@@ -116,9 +116,11 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import division, absolute_import, print_function
+
 import math, numpy
 
-import colormodels
+from . import colormodels
 
 # Assumed physical brightness of the monitor [W/m^2]
 #   80 cd/m^2 * 20.3 mW/cd (assuming light at 556 nm)
@@ -653,13 +655,13 @@ def init (display_intensity = DEFAULT_DISPLAY_INTENSITY):
     _wavelengths [create_table_size-1] = end_wl_nm + 1
     _xyz_colors  [create_table_size-1] = colormodels.xyz_color (0.0, 0.0, 0.0)
     # fill in the middle rows from the source data
-    for i in xrange (0, len (_CIEXYZ_1931_table)):
+    for i in range (0, len (_CIEXYZ_1931_table)):
         (wl,x,y,z) = _CIEXYZ_1931_table [i]
         _wavelengths [i+1] = wl
         _xyz_colors  [i+1] = colormodels.xyz_color (x,y,z)
     # get the integrals of each curve
     integral = numpy.zeros (3)
-    for i in xrange (0, create_table_size-1):
+    for i in range (0, create_table_size-1):
         d_integral = 0.5 * (_xyz_colors [i] + _xyz_colors [i+1]) * delta_wl_nm
         integral += d_integral
     # scale the sampling curves so that:
@@ -672,7 +674,7 @@ def init (display_intensity = DEFAULT_DISPLAY_INTENSITY):
     scaling = num_wl / (integral [1] * display_intensity)
     _xyz_colors *= scaling
     # now calculate all the deltas
-    for i in xrange (0, create_table_size-1):
+    for i in range (0, create_table_size-1):
         _xyz_deltas [i] = _xyz_colors [i+1] - _xyz_colors [i]
     _xyz_deltas [create_table_size-1] = colormodels.xyz_color (0.0, 0.0, 0.0)
 
@@ -688,10 +690,10 @@ def empty_spectrum ():
 
     The result can be passed to xyz_from_spectrum() to convert to an xyz color.
     '''
-    wl_nm_range = xrange (start_wl_nm, end_wl_nm + 1)
+    wl_nm_range = range (start_wl_nm, end_wl_nm + 1)
     num_wl = len (wl_nm_range)
     spectrum = numpy.zeros ((num_wl, 2))
-    for i in xrange (0, num_wl):
+    for i in range (0, num_wl):
         spectrum [i][0] = float (wl_nm_range [i])
     return spectrum
 
@@ -720,7 +722,7 @@ def xyz_from_spectrum (spectrum):
     assert num_col == 2, 'Expecting 2D array with each row: wavelength [nm], specific intensity [W/unit solid angle]'
     # integrate
     rtn = colormodels.xyz_color (0.0, 0.0, 0.0)
-    for i in xrange (0, num_wl):
+    for i in range (0, num_wl):
         wl_nm_i = spectrum [i][0]
         specific_intensity_i = spectrum [i][1]
         xyz = xyz_from_wavelength (wl_nm_i)
@@ -740,7 +742,7 @@ def get_normalized_spectral_line_colors (
     dwl_angstroms - Wavelength separation, in angstroms (0.1 nm).  Default 10 A. (1 nm spacing)
     '''
     # get range of wavelengths, in angstroms, so that we can have finer resolution than 1 nm
-    wl_angstrom_range = xrange (10*start_wl_nm, 10*(end_wl_nm + 1), dwl_angstroms)
+    wl_angstrom_range = range (10*start_wl_nm, 10*(end_wl_nm + 1), dwl_angstroms)
     # get total point count
     num_spectral = len (wl_angstrom_range)
     num_points   = num_spectral + num_purples
@@ -756,7 +758,7 @@ def get_normalized_spectral_line_colors (
     # interpolate from end point to start point (filling in the purples)
     first_xyz = xyzs [0]
     last_xyz  = xyzs [num_spectral - 1]
-    for ipurple in xrange (0, num_purples):
+    for ipurple in range (0, num_purples):
         t = float (ipurple) / float (num_purples - 1)
         omt = 1.0 - t
         xyz = t * first_xyz + omt * last_xyz
@@ -764,7 +766,7 @@ def get_normalized_spectral_line_colors (
         xyzs [i] = xyz
         i += 1
     # scale each color to have the max rgb component equal to the desired brightness
-    for i in xrange (0, num_points):
+    for i in range (0, num_points):
         rgb = colormodels.rgb_from_xyz (xyzs [i])
         max_rgb = max (rgb)
         if max_rgb != 0.0:

--- a/colormodels.py
+++ b/colormodels.py
@@ -248,6 +248,8 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import division, absolute_import, print_function
+
 import math, numpy
 
 # The xyz constructors have some special versions to handle some common situations
@@ -456,8 +458,8 @@ def init (
          phosphor_blue  * intensities [2]))
     # invert to get rgb_from_xyz matrix
     rgb_from_xyz_matrix = numpy.linalg.inv (xyz_from_rgb_matrix)
-    #print 'xyz_from_rgb', str (xyz_from_rgb_matrix)
-    #print 'rgb_from_xyz', str (rgb_from_xyz_matrix)
+    #print('xyz_from_rgb', str (xyz_from_rgb_matrix))
+    #print('rgb_from_xyz', str (rgb_from_xyz_matrix))
 
     # conversions between the (almost) perceptually uniform
     # spaces (Luv, Lab) require the definition of a white point.
@@ -820,7 +822,7 @@ def clip_rgb_color (rgb_color):
             rgb [2] = scaling * (rgb [2] - rgb_min);
             clipped_chromaticity = True
     else:
-        raise ValueError, 'Invalid color clipping method %s' % (str(_clip_method))
+        raise ValueError('Invalid color clipping method %s' % (str(_clip_method)))
             
     # clip intensity if needed (rgb values > 1.0) by scaling
     rgb_max = max (rgb)
@@ -833,7 +835,7 @@ def clip_rgb_color (rgb_color):
         clipped_intensity = True
 
     # gamma correction
-    for index in xrange (0, 3):
+    for index in range (0, 3):
         rgb [index] = display_from_linear_component (rgb [index])
 
     # scale to 0 - 255
@@ -857,7 +859,7 @@ def clip_rgb_color (rgb_color):
 def irgb_string_from_irgb (irgb):
     '''Convert a displayable irgb color (0-255) into a hex string.'''
     # ensure that values are in the range 0-255
-    for index in xrange (0,3):
+    for index in range (0,3):
         irgb [index] = min (255, max (0, irgb [index]))
     # convert to hex string
     irgb_string = '#%02X%02X%02X' % (irgb [0], irgb [1], irgb [2])
@@ -867,9 +869,9 @@ def irgb_from_irgb_string (irgb_string):
     '''Convert a color hex string (like '#AB13D2') into a displayable irgb color.'''
     strlen = len (irgb_string)
     if strlen != 7:
-        raise ValueError, 'irgb_string_from_irgb(): Expecting 7 character string like #AB13D2'
+        raise ValueError('irgb_string_from_irgb(): Expecting 7 character string like #AB13D2')
     if irgb_string [0] != '#':
-        raise ValueError, 'irgb_string_from_irgb(): Expecting 7 character string like #AB13D2'
+        raise ValueError('irgb_string_from_irgb(): Expecting 7 character string like #AB13D2')
     irs = irgb_string [1:3]
     igs = irgb_string [3:5]
     ibs = irgb_string [5:7]

--- a/figures.py
+++ b/figures.py
@@ -42,14 +42,10 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
-import colormodels
-import ciexyz
-import illuminants
-import plots
-import blackbody
-import rayleigh
-import thinfilm
-import misc
+from __future__ import division, absolute_import, print_function
+
+from . import (colormodels, ciexyz, illuminants, plots, blackbody,
+               rayleigh, thinfilm, misc)
 
 def figures ():
     '''Create all the ColorPy sample figures.'''

--- a/illuminants.py
+++ b/illuminants.py
@@ -88,12 +88,11 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import division, absolute_import, print_function
+
 import math, numpy
 
-import colormodels
-import ciexyz
-import blackbody
-import plots
+from . import colormodels, ciexyz, blackbody, plots
 
 # table of CIE Illuminant D65 spectrum.
 # data from: http://cvrl.ioo.ucl.ac.uk/database/data/cie/Illuminantd65.txt
@@ -646,7 +645,7 @@ def init ():
     global _Illuminant_D65
     _Illuminant_D65 = ciexyz.empty_spectrum()
     (num_wl, num_cols) = _Illuminant_D65.shape
-    for i in xrange (0, num_wl):
+    for i in range (0, num_wl):
         _Illuminant_D65 [i][1] = _Illuminant_D65_table [first_index + i][1]
     # normalization - illuminant is scaled so that Y = 1.0
     xyz = ciexyz.xyz_from_spectrum (_Illuminant_D65)
@@ -690,7 +689,7 @@ def get_constant_illuminant ():
     '''Get an illuminant, with spectrum constant over wavelength, normalized to Y = 1.0.'''
     illuminant = ciexyz.empty_spectrum()
     (num_wl, num_cols) = illuminant.shape
-    for i in xrange (0, num_wl):
+    for i in range (0, num_wl):
         illuminant [i][1] = 1.0
     xyz = ciexyz.xyz_from_spectrum (illuminant)
     if xyz [1] != 0.0:

--- a/misc.py
+++ b/misc.py
@@ -61,11 +61,11 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import division, absolute_import, print_function
+
 import math, numpy, pylab
 
-import colormodels
-import ciexyz
-import plots
+from . import colormodels, ciexyz, plots
 
 # Some sample lists of displayable RGB colors as hex strings
 
@@ -275,12 +275,12 @@ def perceptually_uniform_spectral_colors ():
     
     # convert colors to a nearly perceptually uniform space
     uniforms = numpy.empty ((num_colors, 3))
-    for i in xrange (0, num_colors):
+    for i in range (0, num_colors):
         uniforms [i] = uniform_from_xyz (xyzs [i])
     # determine spacing
     sum_ds = 0.0
     dss = numpy.empty ((num_colors, 1))
-    for i in xrange (0, num_colors-1):
+    for i in range (0, num_colors-1):
         dri = uniforms [i+1] - uniforms [i]
         dsi = math.sqrt (numpy.dot (dri, dri))
         dss [i] = dsi

--- a/plots.py
+++ b/plots.py
@@ -121,11 +121,12 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import division, absolute_import, print_function
+
 import math, random
 import numpy, pylab
 
-import colormodels
-import ciexyz
+from . import colormodels, ciexyz
 
 # Miscellaneous utilities for plots
 
@@ -134,7 +135,7 @@ def log_interpolate (y0, y1, num_values):
     between y0 and y1. The first value will be y0, the last y1.'''
     rtn = []
     if num_values <= 0:
-        raise ValueError, 'Invalid number of divisions %s in log_interpolate' % (str (num_values))
+        raise ValueError('Invalid number of divisions %s in log_interpolate' % (str (num_values)))
     if num_values == 1:
         # can't use both endpoints, too constrained
         yi = math.sqrt (y0 * y1)
@@ -142,7 +143,7 @@ def log_interpolate (y0, y1, num_values):
     else:
         # normal case
         beta = math.log (y1 / y0) / float (num_values - 1)
-        for i in xrange (0, num_values):
+        for i in range (0, num_values):
             yi = y0 * math.exp (beta * float (i))
             rtn.append (yi)
     return rtn
@@ -185,7 +186,7 @@ def rgb_patch_plot (
     # make plot with each color with one patch
     pylab.clf()
     num_colors = len (rgb_colors)
-    for i in xrange (0, num_colors):
+    for i in range (0, num_colors):
         (iy, ix) = divmod (i, num_across)
         # get color as a displayable string
         colorstring = colormodels.irgb_string_from_rgb (rgb_colors [i])
@@ -197,7 +198,7 @@ def rgb_patch_plot (
     pylab.axis ('off')
     pylab.title (title)
     if filename is not None:
-        print 'Saving plot %s' % str (filename)
+        print('Saving plot %s' % str (filename))
         pylab.savefig (filename)
 
 def xyz_patch_plot (
@@ -229,7 +230,7 @@ def spectrum_subplot (spectrum):
     (num_wl, num_cols) = spectrum.shape
     # get rgb colors for each wavelength
     rgb_colors = numpy.empty ((num_wl, 3))
-    for i in xrange (0, num_wl):
+    for i in range (0, num_wl):
         wl_nm = spectrum [i][0]
         xyz = ciexyz.xyz_from_wavelength (wl_nm)
         rgb_colors [i] = colormodels.rgb_from_xyz (xyz)
@@ -238,7 +239,7 @@ def spectrum_subplot (spectrum):
     scaling = 1.0 / rgb_max
     rgb_colors *= scaling        
     # draw color patches (thin vertical lines matching the spectrum curve) in color
-    for i in xrange (0, num_wl-1):    # skipping the last one here to stay in range
+    for i in range (0, num_wl-1):    # skipping the last one here to stay in range
         x0 = spectrum [i][0]
         x1 = spectrum [i+1][0]
         y0 = spectrum [i][1]
@@ -294,7 +295,7 @@ def spectrum_plot (
     pylab.ylabel (ylabel)
     # done
     if filename is not None:
-        print 'Saving plot %s' % str (filename)
+        print('Saving plot %s' % str (filename))
         pylab.savefig (filename)
 
 #
@@ -329,7 +330,7 @@ def color_vs_param_plot (
     pylab.title (title)
     # no xlabel, ylabel in upper plot
     num_points = len (param_list)
-    for i in xrange (0, num_points-1):
+    for i in range (0, num_points-1):
         x0 = param_list [i]
         x1 = param_list [i+1]
         y0 = 0.0
@@ -351,7 +352,7 @@ def color_vs_param_plot (
     pylab.xlabel (xlabel)
     pylab.ylabel (ylabel)
     if filename is not None:
-        print 'Saving plot %s' % str (filename)
+        print('Saving plot %s' % str (filename))
         pylab.savefig (filename)
 
 #
@@ -364,7 +365,7 @@ def visible_spectrum_plot ():
     (num_wl, num_cols) = spectrum.shape
     # get rgb colors for each wavelength
     rgb_colors = numpy.empty ((num_wl, 3))
-    for i in xrange (0, num_wl):
+    for i in range (0, num_wl):
         xyz = ciexyz.xyz_from_wavelength (spectrum [i][0])
         rgb = colormodels.rgb_from_xyz (xyz)
         rgb_colors [i] = rgb
@@ -389,7 +390,7 @@ def cie_matching_functions_plot ():
     spectrum_y = ciexyz.empty_spectrum()
     spectrum_z = ciexyz.empty_spectrum()
     (num_wl, num_cols) = spectrum_x.shape
-    for i in xrange (0, num_wl):
+    for i in range (0, num_wl):
         wl_nm = spectrum_x [i][0]
         xyz = ciexyz.xyz_from_wavelength (wl_nm)
         spectrum_x [i][1] = xyz [0]
@@ -417,7 +418,7 @@ def cie_matching_functions_plot ():
     tighten_x_axis (spectrum_x [:,0])
     # done
     filename = 'CIEXYZ_Matching'
-    print 'Saving plot %s' % str (filename)
+    print('Saving plot %s' % str (filename))
     pylab.savefig (filename)
 
 def shark_fin_plot ():
@@ -427,7 +428,7 @@ def shark_fin_plot ():
     # get normalized colors
     xy_list = xyz_list.copy()
     (num_colors, num_cols) = xy_list.shape
-    for i in xrange (0, num_colors):
+    for i in range (0, num_colors):
         colormodels.xyz_normalize (xy_list [i])
     # get phosphor colors and normalize
     red   = colormodels.PhosphorRed
@@ -451,7 +452,7 @@ def shark_fin_plot ():
     pylab.clf ()
     # draw color patches for point in xy_list
     s = 0.025     # distance in xy plane towards white point
-    for i in xrange (0, len (xy_list)-1):
+    for i in range (0, len (xy_list)-1):
         x0 = xy_list [i][0]
         y0 = xy_list [i][1]
         x1 = xy_list [i+1][0]
@@ -486,7 +487,7 @@ def shark_fin_plot ():
     pylab.ylabel (r'CIE $y$')
     pylab.title (r'CIE Chromaticity Diagram')
     filename = 'ChromaticityDiagram'
-    print 'Saving plot %s' % (str (filename))
+    print('Saving plot %s' % (str (filename)))
     pylab.savefig (filename)
 
 # Special figures

--- a/rayleigh.py
+++ b/rayleigh.py
@@ -62,14 +62,12 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import division, absolute_import, print_function
+
 import math
 import numpy, pylab
 
-import colormodels
-import ciexyz
-import illuminants
-import blackbody
-import plots
+from . import colormodels, ciexyz, illuminants, blackbody, plots
 
 def rayleigh_scattering (wl_nm):
     '''Get the Rayleigh scattering factor for the wavelength.
@@ -84,7 +82,7 @@ def rayleigh_scattering_spectrum ():
     '''Get the Rayleigh scattering spectrum (independent of illuminant), as a numpy array.'''
     spectrum = ciexyz.empty_spectrum()
     (num_rows, num_cols) = spectrum.shape
-    for i in xrange (0, num_rows):
+    for i in range (0, num_rows):
         spectrum [i][1] = rayleigh_scattering (spectrum [i][0])
     return spectrum
         
@@ -92,7 +90,7 @@ def rayleigh_illuminated_spectrum (illuminant):
     '''Get the spectrum when illuminated by the specified illuminant.'''
     spectrum = rayleigh_scattering_spectrum()
     (num_wl, num_col) = spectrum.shape
-    for i in xrange (0, num_wl):
+    for i in range (0, num_wl):
         spectrum [i][1] *= illuminant [i][1]
     return spectrum
 
@@ -120,7 +118,7 @@ def rayleigh_color_vs_illuminant_temperature_plot (T_list, title, filename):
     '''Make a plot of the Rayleigh scattered color vs. temperature of blackbody illuminant.'''
     num_T = len (T_list)
     rgb_list = numpy.empty ((num_T, 3))
-    for i in xrange (0, num_T):
+    for i in range (0, num_T):
         T_i = T_list [i]
         illuminant = illuminants.get_blackbody_illuminant (T_i)
         xyz = rayleigh_illuminated_color (illuminant)

--- a/test.py
+++ b/test.py
@@ -27,12 +27,10 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
-import test_colormodels
-import test_ciexyz
-import test_illuminants
-import test_blackbody
-import test_rayleigh
-import test_thinfilm
+from __future__ import division, absolute_import, print_function
+
+from . import (test_colormodels, test_ciexyz, test_illuminants,
+               test_blackbody, test_rayleigh, test_thinfilm)
 
 def test ():
     # no test cases for plots/misc - but figures.py will exercise those.

--- a/test_blackbody.py
+++ b/test_blackbody.py
@@ -22,17 +22,18 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import division, absolute_import, print_function
+
 import math, random, numpy
 
-import colormodels
-import blackbody
+from . import colormodels, blackbody
 
 STEFAN_BOLTZMAN = 5.670e-8        # W/(m^2 K^4)
 
 def blackbody_total_intensity (T_K, start_wl_nm, end_wl_nm):
     '''Get the sum of the specific intensity, at 1 nm increments, from start_wl_nm to end_wl_nm.'''
     total = 0.0
-    for wl_nm in xrange (start_wl_nm, end_wl_nm+1):
+    for wl_nm in range (start_wl_nm, end_wl_nm+1):
         specific = blackbody.blackbody_specific_intensity (wl_nm, T_K)
         total += specific
     return total
@@ -53,7 +54,7 @@ def test_Wyszecki_p29 ():
     '''Calculations re Wyszecki p29 table.'''
     T = 1336.0     # 'Gold' point
     xyz = blackbody.blackbody_color (T)
-    print 'blackbody color at gold point', str (xyz)
+    print('blackbody color at gold point', str (xyz))
     # this source is supposed to be 0.11 cd/cm^2 = 1100 cd/m^2
     # whereas monitors are c. 80 cd/m^2 to 300 cd/m^2
 
@@ -62,18 +63,18 @@ def test_stefan_boltzman (verbose=1):
     NOTE - This currently does not match.  I am not sure what the situation is.'''
     T = 100.0
     sb_test0 = blackbody_total_intensity_stefan_boltzman (T)
-    print 'sb_test0', sb_test0
+    print('sb_test0', sb_test0)
     sb_test1 = blackbody_total_intensity (T, 0, 1000)
-    print 'sb_test1', sb_test1
+    print('sb_test1', sb_test1)
     sb_test2 = blackbody_total_intensity (T, 0, 10000)
-    print 'sb_test2', sb_test2
+    print('sb_test2', sb_test2)
     sb_test3 = blackbody_total_intensity (T, 0, 100000)
-    print 'sb_test3', sb_test3
+    print('sb_test3', sb_test3)
     # following start to get slow...
     #sb_test4 = blackbody_total_intensity (T, 0, 1000000)
-    #print 'sb_test4', sb_test4
+    #print('sb_test4', sb_test4)
     #sb_test5 = blackbody_total_intensity (T, 0, 10000000)
-    #print 'sb_test5', sb_test5
+    #print('sb_test5', sb_test5)
 
     # compare the computed result with the stefan-boltzman formula
     # TODO - these do not match, although the T^4 behavior is observed...
@@ -88,13 +89,13 @@ def test_stefan_boltzman (verbose=1):
         ratio = total4 / total_sb
         #if verbose >= 1:
         if True:
-            print 'T', T
-            print 'total_sb', total_sb
-            print 'total1', total1
-            print 'total2', total2
-            print 'total3', total3
-            print 'total4', total4
-            print 'ratio', ratio
+            print('T', T)
+            print('total_sb', total_sb)
+            print('total1', total1)
+            print('total2', total2)
+            print('total3', total3)
+            print('total4', total4)
+            print('ratio', ratio)
 
 def test_blackbody (verbose=0):
     '''Test the blackbody functions.'''
@@ -112,16 +113,16 @@ def test_blackbody (verbose=0):
     # determine the color for several temperatures - 10000.0 is a particularly good range
     temp_ranges = [100.0, 1000.0, 10000.0, 100000.0, 1000000.0 ]
     for T0 in temp_ranges:    
-        for i in xrange (0, 20):
+        for i in range (0, 20):
             T_K = T0 * random.random()
             xyz = blackbody.blackbody_color (T_K)
             if verbose >= 1:
-                print 'T = %g K, xyz = %s' % (T_K, str (xyz))
+                print('T = %g K, xyz = %s' % (T_K, str (xyz)))
             num_passed += 1   # didn't exception
 
     msg = 'test_blackbody() : %d tests passed, %d tests failed' % (
         num_passed, num_failed)
-    print msg
+    print(msg)
 
 # Table of xy chromaticities for blackbodies
 # From (I think): Judd and Wyszecki, Color in Business, Science and Industry, 1975, p. 164
@@ -158,7 +159,7 @@ def test_book (verbose=1):
     num_failed = 0
    
     (num_rows, num_cols) = book_chrom_table.shape
-    for i in xrange (0, num_rows):
+    for i in range (0, num_rows):
         T = book_chrom_table [i][0]
         book_x = book_chrom_table [i][1]
         book_y = book_chrom_table [i][2]
@@ -177,10 +178,10 @@ def test_book (verbose=1):
         msg = 'test_book() : T = %g : calculated x,y = %g,%g : book values x,y = %g,%g : errors = %g,%g' % (
             T, xyz [0], xyz [1], book_x, book_y, dx, dy)
         if verbose >= 1:
-            print msg
+            print(msg)
         if not passed:
             pass
-            raise ValueError, msg
+            raise ValueError(msg)
         if passed:
             num_passed += 1
         else:
@@ -188,7 +189,7 @@ def test_book (verbose=1):
 
     msg = 'test_book() : %d tests passed, %d tests failed' % (
         num_passed, num_failed)
-    print msg
+    print(msg)
 
 # Tests
 

--- a/test_ciexyz.py
+++ b/test_ciexyz.py
@@ -22,23 +22,25 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import division, absolute_import, print_function
+
 import random
 
-import ciexyz
+from . import ciexyz
 
 def test (verbose=0):
     '''Test the CIE XYZ conversions.  Mainly call some functions.'''
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         wl_nm = 1000.0 * random.random()
         xyz = ciexyz.xyz_from_wavelength (wl_nm)
         if verbose >= 1:
-            print 'wl_nm = %g, xyz = %s' % (wl_nm, str (xyz))
-    for i in xrange (0, 10):
+            print('wl_nm = %g, xyz = %s' % (wl_nm, str (xyz)))
+    for i in range (0, 10):
         empty = ciexyz.empty_spectrum ()
         xyz = ciexyz.xyz_from_spectrum (empty)
         if verbose >= 1:
-            print 'black = %s' % (str (xyz))
+            print('black = %s' % (str (xyz)))
         xyz_555 = ciexyz.xyz_from_wavelength (555.0)
         if verbose >= 1:
-            print '555 nm = %s' % (str (xyz_555))
-    print 'test_ciexyz.test() passed.'
+            print('555 nm = %s' % (str (xyz_555)))
+    print('test_ciexyz.test() passed.')

--- a/test_colormodels.py
+++ b/test_colormodels.py
@@ -22,9 +22,10 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import division, absolute_import, print_function
+
 import math, random, numpy
-import colormodels
-import ciexyz
+from . import colormodels, ciexyz
 
 def test_xyz_rgb (verbose=1):
     '''Test that xyz_to_rgb() and rgb_to_xyz() are inverses.'''
@@ -46,16 +47,16 @@ def test_xyz_rgb (verbose=1):
         msg = 'test_xyz_rgb.test_A() : xyz0 = %s, rgb(xyz0) = %s, xyz(rgb(xyz0)) = %s, rgb(xyz(rgb(xyz0))) = %s, errors = (%g, %g), %s' % (
             str (xyz0), str (rgb0), str (xyz1), str (rgb1), error_rgb, error_xyz, status)
         if verbose >= 1:
-            print msg
+            print(msg)
         if not passed:
             pass
-            raise ValueError, msg
+            raise ValueError(msg)
         return passed
 
     num_passed = 0
     num_failed = 0
 
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         x0 = 10.0 * random.random()
         y0 = 10.0 * random.random()
         z0 = 10.0 * random.random()
@@ -77,11 +78,11 @@ def test_xyz_rgb (verbose=1):
 
     msg = 'test_xyz_rgb() : %d tests passed, %d tests failed' % (
         num_passed, num_failed)
-    print msg
+    print(msg)
 
 def test_xyz_irgb (verbose=1):
     '''Test the direct conversions from xyz to irgb.'''
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         x0 = 10.0 * random.random()
         y0 = 10.0 * random.random()
         z0 = 10.0 * random.random()
@@ -96,7 +97,7 @@ def test_xyz_irgb (verbose=1):
         irgbs1 = colormodels.irgb_string_from_xyz (xyz0)
         if irgbs0 != irgbs1:
             raise ValueError
-    print 'Passed test_xyz_irgb()'
+    print('Passed test_xyz_irgb()')
 
 #
 # Color model conversions to (nearly) perceptually uniform spaces Luv and Lab.
@@ -110,7 +111,7 @@ def calc_L_LUM_C ():
     '''L_LUM_C should be ideally chosen so that the two models in L_luminance() agree exactly at the cutoff point.
     This is where the extra digits in L_LUM_C, over Kasson, come from.'''
     wanted = (colormodels.L_LUM_A * math.pow (colormodels.L_LUM_CUTOFF, 1.0/3.0) - colormodels.L_LUM_B) / colormodels.L_LUM_CUTOFF
-    print 'optimal L_LUM_C = %.16e' % (wanted)
+    print('optimal L_LUM_C = %.16e' % (wanted))
 
 def test_L_luminance (verbose=1):
     '''Test that L_luminance() and L_luminance_inverse() are really inverses.'''
@@ -134,10 +135,10 @@ def test_L_luminance (verbose=1):
         msg = 'test_L_luminance.test_A() : y0 = %g (%s), L(y0) = %g, y(L(y0)) = %g, error = %g, %s' % (
             y0, range_info, L0, y1, error, status)
         if verbose >= 1:
-            print msg
+            print(msg)
         if not passed:
             pass
-            raise ValueError, msg
+            raise ValueError(msg)
         return passed
 
     # Test B - Check that L_luminance() is the inverse of L_luminance_inverse()
@@ -160,17 +161,17 @@ def test_L_luminance (verbose=1):
         msg = 'test_L_luminance.test_B() : L0 = %g (%s), y(L0) = %g, L(y(L0)) = %g, error = %g, %s' % (
             L0, range_info, y0, L1, error, status)
         if verbose >= 1:
-            print msg
+            print(msg)
         if not passed:
             pass
-            raise ValueError, msg
+            raise ValueError(msg)
         return passed
 
     num_passed = 0
     num_failed = 0
 
     # Test A for fairly small y values (to ensure coverage of linear range)
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         y0 = 0.1 * random.random()
         passed = test_A (y0, tolerance=1.0e-13, verbose=verbose)
         if passed:
@@ -179,7 +180,7 @@ def test_L_luminance (verbose=1):
             num_failed += 1
         
     # Test A for fairly large y values
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         y0 = 10.0 * random.random()
         passed = test_A (y0, tolerance=1.0e-13, verbose=verbose)
         if passed:
@@ -188,7 +189,7 @@ def test_L_luminance (verbose=1):
             num_failed += 1
 
     # Test B for fairly small L values (to ensure coverage of linear range)
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         L0 = 50.0 * random.random()
         passed = test_B (L0, tolerance=1.0e-10, verbose=verbose)
         if passed:
@@ -197,7 +198,7 @@ def test_L_luminance (verbose=1):
             num_failed += 1
         
     # Test B for fairly large L values
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         L0 = 1000.0 * random.random()
         passed = test_B (L0, tolerance=1.0e-10, verbose=verbose)
         if passed:
@@ -207,7 +208,7 @@ def test_L_luminance (verbose=1):
 
     msg = 'test_L_luminance() : %d tests passed, %d tests failed' % (
         num_passed, num_failed)
-    print msg
+    print(msg)
 
 # Utility function for Luv
 
@@ -228,10 +229,10 @@ def test_uv_primes (verbose=1):
         msg = 'test_uv_primes.test_A() : xyz0 = %s, (up,vp) = (%g,%g), xyz(up,vp) = %s, error = %g, %s' % (
             str (xyz0), up0, vp0, str(xyz1), error, status)
         if verbose >= 1:
-            print msg
+            print(msg)
         if not passed:
             pass
-            raise ValueError, msg
+            raise ValueError(msg)
         return passed
 
     def test_B (up0, vp0, y0, tolerance=0.0, verbose=1):
@@ -249,17 +250,17 @@ def test_uv_primes (verbose=1):
         msg = 'test_uv_primes.test_B() : (up0,vp0,y0) = (%g,%g,%g), xyz (up0,vp0,y0) = %s, (up,vp)(xyz) = (%g,%g), error = %g, %s' % (
             up0, vp0, y0, str (xyz0), up1, vp1, error, status)
         if verbose >= 1:
-            print msg
+            print(msg)
         if not passed:
             pass
-            raise ValueError, msg
+            raise ValueError(msg)
         return passed
         
     num_passed = 0
     num_failed = 0
 
     # Test A
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         x0 = 10.0 * random.random()
         y0 = 10.0 * random.random()
         z0 = 10.0 * random.random()
@@ -279,7 +280,7 @@ def test_uv_primes (verbose=1):
         num_failed += 1
 
     # Test B
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         up0 = 4.0 * (2.0 * random.random() - 1.0)
         vp0 = 9.0 * (2.0 * random.random() - 1.0)
         y0 = 10.0 * random.random()
@@ -298,7 +299,7 @@ def test_uv_primes (verbose=1):
 
     msg = 'test_uv_primes() : %d tests passed, %d tests failed' % (
         num_passed, num_failed)
-    print msg
+    print(msg)
 
 # Utility function for Lab
 #     See [Kasson p.399] for details.
@@ -309,7 +310,7 @@ def calc_LAB_F_A ():
     '''LAB_F_A should be ideally chosen so that the two models in Lab_f() agree exactly at the cutoff point.
     This is where the extra digits in LAB_F_A, over Kasson, come from.'''
     wanted = (math.pow (colormodels.L_LUM_CUTOFF, 1.0/3.0) - colormodels.LAB_F_B) / colormodels.L_LUM_CUTOFF
-    print 'optimal LAB_F_A = %.16e' % (wanted)
+    print('optimal LAB_F_A = %.16e' % (wanted))
 
 def test_Lab_f (verbose=1):
     '''Test that Lab_f() and Lab_f_inverse() are really inverses.'''
@@ -333,10 +334,10 @@ def test_Lab_f (verbose=1):
         msg = 'test_Lab_f.test_A() : t0 = %g (%s), f(t0) = %g, t(f(t0)) = %g, error = %g, %s' % (
             t0, range_info, f0, t1, error, status)
         if verbose >= 1:
-            print msg
+            print(msg)
         if not passed:
             pass
-            raise ValueError, msg
+            raise ValueError(msg)
         return passed
 
     # Test B - Check that Lab_f() is the inverse of Lab_f_inverse()
@@ -359,17 +360,17 @@ def test_Lab_f (verbose=1):
         msg = 'test_Lab_f.test_B() : f0 = %g (%s), t(f0) = %g, f(t(f0)) = %g, error = %g, %s' % (
             f0, range_info, t0, f1, error, status)
         if verbose >= 1:
-            print msg
+            print(msg)
         if not passed:
             pass
-            raise ValueError, msg
+            raise ValueError(msg)
         return passed
 
     num_passed = 0
     num_failed = 0
 
     # Test A for fairly small y values (to ensure coverage of linear range)
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         y0 = 0.025 * random.random()
         passed = test_A (y0, tolerance=1.0e-13, verbose=verbose)
         if passed:
@@ -378,7 +379,7 @@ def test_Lab_f (verbose=1):
             num_failed += 1
 
     # Test A for fairly large y values
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         y0 = 10.0 * random.random()
         passed = test_A (y0, tolerance=1.0e-13, verbose=verbose)
         if passed:
@@ -387,7 +388,7 @@ def test_Lab_f (verbose=1):
             num_failed += 1
 
     # Test B for fairly small L values (to ensure coverage of linear range)
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         L0 = 0.25 * random.random()
         passed = test_B (L0, tolerance=1.0e-10, verbose=verbose)
         if passed:
@@ -396,7 +397,7 @@ def test_Lab_f (verbose=1):
             num_failed += 1
         
     # Test B for fairly large L values
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         L0 = 1000.0 * random.random()
         passed = test_B (L0, tolerance=1.0e-10, verbose=verbose)
         if passed:
@@ -406,7 +407,7 @@ def test_Lab_f (verbose=1):
 
     msg = 'test_Lab_f() : %d tests passed, %d tests failed' % (
         num_passed, num_failed)
-    print msg
+    print(msg)
 
 # Conversions between standard device independent color space (CIE XYZ)
 # and the almost perceptually uniform space Luv.
@@ -432,16 +433,16 @@ def test_xyz_luv (verbose=1):
         msg = 'test_xyz_luv.test_A() : xyz0 = %s, luv(xyz0) = %s, xyz(luv(xyz0)) = %s, luv(xyz(luv(xyz0))) = %s, errors = (%g, %g), %s' % (
             str (xyz0), str (luv0), str (xyz1), str (luv1), error_luv, error_xyz, status)
         if verbose >= 1:
-            print msg
+            print(msg)
         if not passed:
             pass
-            raise ValueError, msg
+            raise ValueError(msg)
         return passed
 
     num_passed = 0
     num_failed = 0
 
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         x0 = 10.0 * random.random()
         y0 = 10.0 * random.random()
         z0 = 10.0 * random.random()
@@ -462,7 +463,7 @@ def test_xyz_luv (verbose=1):
 
     msg = 'test_xyz_luv() : %d tests passed, %d tests failed' % (
         num_passed, num_failed)
-    print msg
+    print(msg)
 
 # Conversions between standard device independent color space (CIE XYZ)
 # and the almost perceptually uniform space Lab.
@@ -488,16 +489,16 @@ def test_xyz_lab (verbose=1):
         msg = 'test_xyz_lab.test_A() : xyz0 = %s, lab(xyz0) = %s, xyz(lab(xyz0)) = %s, lab(xyz(lab(xyz0))) = %s, errors = (%g, %g), %s' % (
             str (xyz0), str (lab0), str (xyz1), str (lab1), error_lab, error_xyz, status)
         if verbose >= 1:
-            print msg
+            print(msg)
         if not passed:
             pass
-            raise ValueError, msg
+            raise ValueError(msg)
         return passed
 
     num_passed = 0
     num_failed = 0
 
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         x0 = 10.0 * random.random()
         y0 = 10.0 * random.random()
         z0 = 10.0 * random.random()
@@ -518,17 +519,17 @@ def test_xyz_lab (verbose=1):
 
     msg = 'test_xyz_lab() : %d tests passed, %d tests failed' % (
         num_passed, num_failed)
-    print msg
+    print(msg)
 
 # Gamma correction
 
 def test_gamma (verbose=1):
     if verbose >= 1:
-        print 'Testing gamma corrections...'
+        print('Testing gamma corrections...')
 
     def test_gamma_corrections ():
         # test individual component gamma
-        for i in xrange (0, 100):
+        for i in range (0, 100):
             x = 10.0 * (2.0 * random.random() - 1.0)
             a = colormodels.linear_from_display_component (x)
             b = colormodels.display_from_linear_component (a)
@@ -538,8 +539,8 @@ def test_gamma (verbose=1):
             rel1 = math.fabs (err1 / (b + x))
             err2 = math.fabs (c - a)
             rel2 = math.fabs (err2 / (c + a))
-            #print 'x = %g, b = %g, err = %g, rel = %g' % (x, b, err1, rel1)
-            #print 'a = %g, c = %g, err = %g, rel = %g' % (a, c, err2, rel2)
+            #print('x = %g, b = %g, err = %g, rel = %g' % (x, b, err1, rel1))
+            #print('a = %g, c = %g, err = %g, rel = %g' % (a, c, err2, rel2))
             tolerance = 1.0e-14
             if rel1 > tolerance:
                 raise ValueError
@@ -548,7 +549,7 @@ def test_gamma (verbose=1):
 
     # test default sRGB component (cannot supply exponent)
     if verbose >= 1:
-        print 'testing sRGB gamma'
+        print('testing sRGB gamma')
     colormodels.init_gamma_correction (
         display_from_linear_function = colormodels.srgb_gamma_invert,
         linear_from_display_function = colormodels.srgb_gamma_correct)
@@ -558,20 +559,20 @@ def test_gamma (verbose=1):
     gamma_set = [0.1, 0.5, 1.0, 1.1, 1.5, 2.0, 2.2, 2.5, 10.0]
     for gamma in gamma_set:
         if verbose >= 1:
-            print 'testing gamma', gamma
+            print('testing gamma', gamma)
         colormodels.init_gamma_correction (
             display_from_linear_function = colormodels.simple_gamma_invert,
             linear_from_display_function = colormodels.simple_gamma_correct,
             gamma = gamma)
         test_gamma_corrections()
 
-    print 'Passed test_gamma()'
+    print('Passed test_gamma()')
 
 # Linear (0.0-1.0) rgb to/from displayable (0-255) irgb
 
 def test_irgb_string (verbose=1):
     '''Convert back and forth from irgb and irgb_string.'''
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         ir = random.randrange (0, 256)
         ig = random.randrange (0, 256)
         ib = random.randrange (0, 256)
@@ -581,16 +582,16 @@ def test_irgb_string (verbose=1):
         irgb_string2 = colormodels.irgb_string_from_irgb (irgb2)
         if (irgb[0] != irgb2[0]) or (irgb[1] != irgb2[1]) or (irgb[2] != irgb2[2]):
             msg = 'irgb %s and irgb2 %s do not match' % (str (irgb), str (irgb2))
-            raise ValueError, msg
+            raise ValueError(msg)
         if (irgb_string != irgb_string2):
             msg = 'irgb_string %s and irgb_string2 %s do not match' % (irgb_string, irgb_string2)
-            raise ValueError, msg
+            raise ValueError(msg)
     if verbose >= 1:
-        print 'Passed test_irgb_string()'
+        print('Passed test_irgb_string()')
 
 def test_rgb_irgb (verbose=1):
     '''Test that conversions between rgb and irgb are invertible.'''
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         ir = random.randrange (0, 256)
         ig = random.randrange (0, 256)
         ib = random.randrange (0, 256)
@@ -600,7 +601,7 @@ def test_rgb_irgb (verbose=1):
         rgb1 = colormodels.rgb_from_irgb (irgb1)
         if (irgb0[0] != irgb1[0]) or (irgb0[1] != irgb1[1]) or (irgb0[2] != irgb1[2]):
             msg = 'irgb0 %s and irgb1 %s do not match' % (str (irgb0), str (irgb1))
-            raise ValueError, msg
+            raise ValueError(msg)
         tolerance = 1.0e-14
         err_rgb = rgb1 - rgb0
         err_r = math.fabs (err_rgb [0])
@@ -608,37 +609,37 @@ def test_rgb_irgb (verbose=1):
         err_b = math.fabs (err_rgb [2])
         if (err_r > tolerance) or (err_g > tolerance) or (err_b > tolerance):
             msg = 'rgb0 %s and rgb1 %s differ by %g' % (str (rgb0), str (rgb1), max (err_r,err_g,err_b))
-            raise ValueError, msg
+            raise ValueError(msg)
     if verbose >= 1:
-        print 'Passed test_rgb_irgb()'
+        print('Passed test_rgb_irgb()')
 
 # Clipping
 
 def test_clipping (verbose=1):
     '''Test the various color clipping methods.'''
     xyz_colors = ciexyz.get_normalized_spectral_line_colors ()
-    #print 'xyz_colors', xyz_colors
+    #print('xyz_colors', xyz_colors)
     (num_wl, num_cols) = xyz_colors.shape
     # get rgb values for standard clipping
     colormodels.init_clipping (colormodels.CLIP_ADD_WHITE)
     rgb_add_white = []
-    for i in xrange (0, num_wl):
+    for i in range (0, num_wl):
         color = colormodels.irgb_string_from_rgb (
             colormodels.rgb_from_xyz (xyz_colors [i]))
         rgb_add_white.append (color)
     # get rgb values for clamp clipping
     colormodels.init_clipping (colormodels.CLIP_CLAMP_TO_ZERO)
     rgb_clamp = []
-    for i in xrange (0, num_wl):
+    for i in range (0, num_wl):
         color = colormodels.irgb_string_from_rgb (
             colormodels.rgb_from_xyz (xyz_colors [i]))
         rgb_clamp.append (color)
     # compare
     if verbose >= 1:
-        print 'colors from add white, colors from clamp'
-        for i in xrange (0, num_wl):
-            print rgb_add_white [i], rgb_clamp [i]
-    print 'Passed test_clipping()'
+        print('colors from add white, colors from clamp')
+        for i in range (0, num_wl):
+            print(rgb_add_white [i], rgb_clamp [i])
+    print('Passed test_clipping()')
             
 #
 # Main test routine for the conversions

--- a/test_illuminants.py
+++ b/test_illuminants.py
@@ -22,28 +22,30 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
-import illuminants
+from __future__ import division, absolute_import, print_function
+
+from . import illuminants
 
 def test (verbose=0):
     '''Mainly call some functions.'''
     D65 = illuminants.get_illuminant_D65()
     if verbose >= 1:
-        print 'Illuminant D65'
-        print str (D65)
+        print('Illuminant D65')
+        print(str (D65))
     A = illuminants.get_illuminant_A()
     if verbose >= 1:
-        print 'Illuminant A'
-        print str (A)
+        print('Illuminant A')
+        print(str (A))
     const = illuminants.get_constant_illuminant()
     if verbose >= 1:
-        print 'Constant Illuminant'
-        print str (const)
+        print('Constant Illuminant')
+        print(str (const))
 
     T_list = [0.0, 1.0, 100.0, 1000.0, 5778.0, 10000.0, 100000.0]
     for T in T_list:
         bb = illuminants.get_blackbody_illuminant (T)
         if verbose >= 1:
-            print 'Blackbody Illuminant : %g K' % (T)
-            print str (bb)
-    print 'test_illuminants.test() passed.'
+            print('Blackbody Illuminant : %g K' % (T))
+            print(str (bb))
+    print('test_illuminants.test() passed.')
    

--- a/test_rayleigh.py
+++ b/test_rayleigh.py
@@ -22,19 +22,20 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import division, absolute_import, print_function
+
 import random
 
-import rayleigh
-import illuminants
+from . import rayleigh, illuminants
 
 def test ():
     '''Mainly call some functions.'''
-    for i in xrange (0, 100):
+    for i in range (0, 100):
         wl_nm = 1000.0 * random.random()
         rayleigh.rayleigh_scattering (wl_nm)
     rayleigh.rayleigh_scattering_spectrum()
     illum = illuminants.get_illuminant_D65()
     rayleigh.rayleigh_illuminated_spectrum (illum)
     rayleigh.rayleigh_illuminated_color (illum)
-    print 'test_rayleigh.test() passed.'  # didnt exception
+    print('test_rayleigh.test() passed.')  # didnt exception
 

--- a/test_thinfilm.py
+++ b/test_thinfilm.py
@@ -22,25 +22,26 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import division, absolute_import, print_function
+
 import random
 
-import illuminants
-import thinfilm
+from . import illuminants, thinfilm
 
 def test ():
     '''Module test.  Mainly call some functions.'''
     illuminant = illuminants.get_illuminant_D65()
-    for j in xrange (0, 100):
+    for j in range (0, 100):
         n1 = 5.0 * random.random()
         n2 = 5.0 * random.random()
         n3 = 5.0 * random.random()
         thickness_nm = 10000.0 * random.random()
         film = thinfilm.thin_film (n1, n2, n3, thickness_nm)
-        for k in xrange (0, 100):
+        for k in range (0, 100):
             wl_nm = 1000.0 * random.random()
             film.get_interference_reflection_coefficient (wl_nm)
         film.reflection_spectrum ()
         film.illuminated_spectrum (illuminant)
         film.illuminated_color (illuminant)
-    print 'test_thinfilm.test() passed.'     # no exceptions
+    print('test_thinfilm.test() passed.')     # no exceptions
         

--- a/thinfilm.py
+++ b/thinfilm.py
@@ -82,13 +82,12 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with ColorPy.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import division, absolute_import, print_function
+
 import math, cmath, numpy
 import pylab
 
-import colormodels
-import ciexyz
-import illuminants
-import plots
+from . import colormodels, ciexyz, illuminants, plots
 
 class thin_film:
     '''A thin film of dielectric material.'''
@@ -148,7 +147,7 @@ class thin_film:
         '''Get the reflection spectrum (independent of illuminant) for the thin film.'''
         spectrum = ciexyz.empty_spectrum()
         (num_rows, num_cols) = spectrum.shape
-        for i in xrange (0, num_rows):
+        for i in range (0, num_rows):
             wl_nm = spectrum [i][0]
             spectrum [i][1] = self.get_interference_reflection_coefficient (wl_nm)
         return spectrum
@@ -157,7 +156,7 @@ class thin_film:
         '''Get the spectrum when illuminated by the specified illuminant.'''
         spectrum = self.reflection_spectrum()
         (num_wl, num_col) = spectrum.shape
-        for i in xrange (0, num_wl):
+        for i in range (0, num_wl):
             spectrum [i][1] *= illuminant [i][1]
         return spectrum
 
@@ -184,7 +183,7 @@ def thinfilm_color_vs_thickness_plot (n1, n2, n3, thickness_nm_list, illuminant,
     '''Plot the color of the thin film for the specfied thicknesses [nm].'''
     num_thick = len (thickness_nm_list)
     rgb_list = numpy.empty ((num_thick, 3))
-    for i in xrange (0, num_thick):
+    for i in range (0, num_thick):
         film = thin_film (n1, n2, n3, thickness_nm_list [i])
         xyz = film.illuminated_color (illuminant)
         rgb_list [i] = colormodels.rgb_from_xyz (xyz)
@@ -210,15 +209,15 @@ def thinfilm_spectrum_plot (n1, n2, n3, thickness_nm, illuminant, title, filenam
 def figures ():
     '''Draw some thin film plots.'''
     # simple patch plot
-    thickness_nm_list = xrange (0, 1000, 10)
+    thickness_nm_list = range (0, 1000, 10)
     illuminant = illuminants.get_illuminant_D65()
     illuminants.scale_illuminant (illuminant, 9.50)
     thinfilm_patch_plot (1.500, 1.003, 1.500, thickness_nm_list, illuminant, 'ThinFilm Patch Plot', 'ThinFilm-Patch')
     
     # plot the colors of films vs thickness.
     # we scale the illuminant to get a better range of color.
-    #thickness_nm_list = xrange (0, 1000, 2)   # faster
-    thickness_nm_list = xrange (0, 1000, 1)    # nicer
+    #thickness_nm_list = range (0, 1000, 2)   # faster
+    thickness_nm_list = range (0, 1000, 1)    # nicer
     # gap in glass/plastic
     illuminant = illuminants.get_illuminant_D65()
     illuminants.scale_illuminant (illuminant, 4.50)


### PR DESCRIPTION
After this change, the tests pass and figures are created in both python 2.7 and 3.3.

Changing the division rule will create bugs if there is any integer division. I looked pretty carefully for integer division, and I couldn't find any. So hopefully everything is OK!

Switching xrange(N) to range(N) makes negligible difference in performance or memory for Python 2 for small N (at least up to 10,000 or so).

"raise E,V" is the same as "raise E(V)" in Python 2, but only the latter is legal in Python 3.
